### PR TITLE
[WIP] Format Converters

### DIFF
--- a/packages/converters/RAMONtoRaw.m
+++ b/packages/converters/RAMONtoRaw.m
@@ -1,0 +1,8 @@
+function RAMONtoRaw(RAMONVolInFile, RAMONVolOutFile)
+
+%Should be called cube
+load(RAMONVolInFile)
+
+cube = cube.data;
+
+save(RAMONVolOutFile, 'cube') %-v7.3 TODO

--- a/packages/converters/RAMONtoTIFF.m
+++ b/packages/converters/RAMONtoTIFF.m
@@ -1,0 +1,11 @@
+function RAMONtoTIFF(fileIn, fileOut)
+% Save RAMON volume data to a tiff-stack file
+
+load(fileIn)
+im = cube;
+
+for ii = 1:size(im.data,3)
+    imwrite(im.data(:,:,ii), fileOut, 'writemode', 'append');
+end
+
+end

--- a/packages/converters/RawtoRAMON.m
+++ b/packages/converters/RawtoRAMON.m
@@ -1,0 +1,13 @@
+function RawtoRAMON(RAMONVolInFile, RAMONVolOutFile, queryFile, padX, padY, padZ)
+
+%Should be called cube
+load(RAMONVolInFile)
+load(queryFile)
+
+data = cube;
+
+cube = RAMONVolume;
+cube.setCutout(data);
+cube.setResolution(query.resolution);
+cube.setXyzOffset([query.xRange(1)+padX,query.yRange(1)+padY,query.zRange(1)+padZ]); %TODO
+save(RAMONVolOutFile, 'cube') %-v7.3 TODO

--- a/packages/converters/TIFFtoRAMON.m
+++ b/packages/converters/TIFFtoRAMON.m
@@ -1,0 +1,23 @@
+function TIFFtoRAMON(tiffIn, fileOut, queryFile, padX, padY, padZ)
+% Save tiff stack as ramon
+% ask jordan (github j6k4m8) when this breaks
+
+load(queryFile);
+
+xSize = xRange(2) - xRange(1);
+ySize = yRange(2) - yRange(1);
+zSize = zRange(2) - zRange(1);
+
+data = zeros(xSize, ySize, zSize);
+
+for ii = 1:size(im.data,3)
+    data(:,:,ii) = imread(tiffIn, ii);
+end
+
+cube = RAMONVolume;
+cube.setCutout(data);
+cube.setResolution(query.resolution);
+cube.setXyzOffset([query.xRange(1)+padX,query.yRange(1)+padY,query.zRange(1)+padZ]);
+save(fileOut, 'cube')
+
+end

--- a/packages/converters/TIFFtoRaw.m
+++ b/packages/converters/TIFFtoRaw.m
@@ -1,0 +1,12 @@
+function TIFFtoRaw(tiffIn, fileOut)
+% Convert tiff stack to raw
+% ask jordan (github j6k4m8) when this breaks
+
+
+for ii = 1:size(im.data,3)
+    data(:,:,ii) = imread(tiffIn, ii);
+end
+
+save(fileOut, 'data');
+
+end

--- a/packages/converters/convertCAJAL.m
+++ b/packages/converters/convertCAJAL.m
@@ -1,0 +1,73 @@
+function convertCAJAL(inFile, outFile, queryFile, inFmt, outFmt, padX, padY, padZ)
+% CONVERTCAJAL Anything-to-anything converter for CAJAL.
+% Complain to @j6k4m8 when it breaks.
+
+% Supported Formats
+%    raw, mat
+%    RAMON
+%    tiff
+%    hdf5
+
+if inFmt == outFmt
+    tmp = load(inFile);
+    save(outFile, 'tmp');
+    return;
+end
+
+
+tempFile = 'conversion.tmp';
+
+
+% User only specified inFile, outFile, queryFile.
+% Fill in the rest automatically.
+if nargins == 3
+    inSplit = strsplit(inFile, '.');
+    inFmt = inSplit(end);
+
+    outSplit = strsplit(outFile, '.');
+    outFmt = outSplit(end);
+end
+
+
+% Check if padding was supplied. If not, default to 0.
+if nargins <= 5
+    padX = 0; padY = 0; padZ = 0;
+end
+
+
+switch inFmt
+    % Raw
+    case {'m', 'raw'}
+        tempFile = inFile;
+    % TIFF
+    case {'tif', 'tiff'}
+        TIFFtoRaw(fileIn, tempFile);
+    % HDF5
+    case {'h5', 'hdf5'}
+        HDF5toRaw(fileIn, tempFile);
+    otherwise
+        warning('Assuming raw input.');
+end
+
+% By the time we get here, we have a file at `tempFile` that
+% contains raw data.
+
+% Now we can convert it to a target fmt.
+switch outFmt
+    % Raw
+    case {'m', 'raw'}
+        outFile = tempFile;
+    % TIFF
+    case {'tif', 'tiff'}
+        RawtoTIFF(tempFile, outFile);
+    % HDF5
+    case {'h5', 'hdf5'}
+        RawtoHDF5(tempFile, outFile);
+    % RAMON
+    case {'ramon', 'RAMON'}
+        RawtoRAMON(tempFile, outFile, queryFile, padX, padY, padZ);
+    otherwise
+        warning('Returning raw input.');
+end
+
+end


### PR DESCRIPTION
Work in progress.

**To Raw**

| Format | Implemented | Tested |
| --- | --- | --- |
| RAMON | :white_check_mark: | :white_check_mark: |
| Raw | :white_check_mark: | :white_check_mark: |
| TIFF | :white_check_mark: | :no_entry: |
| HDF5 | :no_entry: | :no_entry: |

**To RAMON**

| Format | Implemented | Tested |
| --- | --- | --- |
| RAMON | :white_check_mark: | :white_check_mark: |
| Raw | :white_check_mark: | :white_check_mark: |
| TIFF | :white_check_mark: | :no_entry: |
| HDF5 | :no_entry: | :no_entry: |

Use the `convertCAJAL` function to convert anything to anything. For instance:

| Function Call | Use Case |
| --- | --- |
| `convertCAJAL('myRawData.m', 'myTiffStack.tiff');` | Convert from `.m` to `.tiff` (auto-guess formats) |
| `convertCAJAL('myRawData.m', 'myVolume.m', queryFile, 'ramon', 'raw');` | Convert from raw to RAMON, using `queryFile`. |
| `convertCAJAL('myRawData.m', 'myVolume.m', queryFile, 'ramon', 'raw', 12, 12, 12);` | Convert from raw to RAMON, using `queryFile`, and adding 12 units padding. |
